### PR TITLE
Modify generation function to return log probability per token for further sequence analysis

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -47,7 +47,7 @@ def main():
     # Sample sequences.
     
     print('Generated sequences:')
-    output_seqs, output_scores = generate(
+    output_seqs, output_scores, generated_logprobs = generate(
         [ args.prompt ] * args.n_samples,
         model,
         tokenizer,


### PR DESCRIPTION
Thanks a lot for your exceptional work and model.

In the TogetherAPI call, you can generate log probability per token for downstream sequence analysis, as you demonstrated in your notebook #19.

This is a minor modification to provide the same functionality to local users through the **generate** library of Evo.