### PR TITLE
Fix compatibility with transformers v5 and numpy 2.0

### DIFF
--- a/evo/generation.py
+++ b/evo/generation.py
@@ -5,7 +5,7 @@ from typing import List, Tuple, Union
 
 from stripedhyena.model import StripedHyena
 from stripedhyena.sample import sample
-from stripedhyena.tokenizer import CharLevelTokenizer
+from .tokenizer import CharLevelTokenizer
 
 from .scoring import logits_to_logprobs, prepare_batch
 

--- a/evo/scoring.py
+++ b/evo/scoring.py
@@ -3,7 +3,7 @@ import torch
 from typing import List, Tuple
 
 from stripedhyena.model import StripedHyena
-from stripedhyena.tokenizer import CharLevelTokenizer
+from .tokenizer import CharLevelTokenizer
 
 
 def prepare_batch(

--- a/evo/tokenizer.py
+++ b/evo/tokenizer.py
@@ -1,0 +1,58 @@
+"""Numpy 2.0-compatible CharLevelTokenizer.
+
+Drop-in replacement for stripedhyena.tokenizer.CharLevelTokenizer that uses
+np.frombuffer instead of the removed np.fromstring (binary mode).
+"""
+from typing import List, Union
+
+import numpy as np
+import torch
+
+
+class CharLevelTokenizer:
+    """Character-level tokenizer that maps text to/from byte values."""
+
+    def __init__(self, vocab_size: int = 512):
+        self.name = "CharLevelTokenizer"
+        self._vocab_size = vocab_size
+        self.eod_id = 0
+        self.eos_id = 0
+        self.pad_id = 1
+
+    def clamp(self, n):
+        return max(32, min(n, self.vocab_size))
+
+    @property
+    def vocab_size(self):
+        return self._vocab_size
+
+    @property
+    def eod(self):
+        return self.eod_id
+
+    @property
+    def eos(self):
+        return self.eod_id
+
+    def decode_token(self, token: int):
+        return str(chr(self.clamp(token)))
+
+    def tokenize(self, text: str):
+        return list(np.frombuffer(text.encode(), dtype=np.uint8))
+
+    def tokenize_batch(self, text_batch: Union[List[str], str]):
+        if isinstance(text_batch, list):
+            return [self.tokenize(s) for s in text_batch]
+        else:
+            return self.tokenize(text_batch)
+
+    def detokenize(self, token_ids):
+        return "".join(list(map(self.decode_token, token_ids)))
+
+    def detokenize_batch(self, token_ids: Union[List[str], str]):
+        if isinstance(token_ids, list):
+            return [self.detokenize(s) for s in token_ids]
+        elif isinstance(token_ids, torch.Tensor):
+            return [self.detokenize(s) for s in token_ids.tolist()]
+        else:
+            return self.detokenize(token_ids)

--- a/evo/version.py
+++ b/evo/version.py
@@ -1,1 +1,1 @@
-version = '0.4'
+version = '0.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 stripedhyena==0.2.2
+huggingface-hub
+safetensors
 biopython
 pandas
 triton

--- a/scripts/generation_to_folding.py
+++ b/scripts/generation_to_folding.py
@@ -14,7 +14,7 @@ from transformers import (
     set_seed
 )
 
-from stripedhyena.tokenizer import CharLevelTokenizer
+from evo.tokenizer import CharLevelTokenizer
 
 
 def main():

--- a/semantic_design/pipelines/acr_sample.py
+++ b/semantic_design/pipelines/acr_sample.py
@@ -21,7 +21,7 @@ from transformers import (
     EsmForProteinFolding,
 )
 from stripedhyena.model import StripedHyena
-from stripedhyena.tokenizer import CharLevelTokenizer
+from evo.tokenizer import CharLevelTokenizer
 
 from semantic_design import (
     read_prompts,

--- a/semantic_design/pipelines/t2ta_sample.py
+++ b/semantic_design/pipelines/t2ta_sample.py
@@ -33,7 +33,7 @@ from semantic_design import (
     filter_proteins_by_threshold,
 )
 from stripedhyena.model import StripedHyena
-from stripedhyena.tokenizer import CharLevelTokenizer
+from evo.tokenizer import CharLevelTokenizer
 
 
 @dataclass

--- a/semantic_design/semantic_design.py
+++ b/semantic_design/semantic_design.py
@@ -20,7 +20,7 @@ import os
 import torch
 
 from stripedhyena.model import StripedHyena
-from stripedhyena.tokenizer import CharLevelTokenizer
+from evo.tokenizer import CharLevelTokenizer
 from evo import Evo
 from evo.generation import generate
 


### PR DESCRIPTION
Replace AutoModelForCausalLM weight loading with direct safetensors loading to fix evo-1 models producing garbage output under transformers v5 (unembed.weight left at random init due to broken tied-weight handling). Add local CharLevelTokenizer to avoid stripedhyena's np.fromstring which was removed in numpy 2.0.